### PR TITLE
Run ci commands on package.json and package-lock.json changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 commands:
   exit-if-no-changes:
     steps:
-      - run: scripts/exit-if-no-changes.sh packages e2e-tests .circleci
+      - run: scripts/exit-if-no-changes.sh package.json packages e2e-tests .circleci
   install:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 commands:
   exit-if-no-changes:
     steps:
-      - run: scripts/exit-if-no-changes.sh package.json packages e2e-tests .circleci
+      - run: scripts/exit-if-no-changes.sh package.json package-lock.json packages e2e-tests .circleci
   install:
     steps:
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "gatsby-multilingual",
   "private": true,
   "license": "MIT",
-  "custom_flag": "custom_value",
   "repository": "github:ervasive/gatsby-multilingual",
   "scripts": {
     "ts:compile": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gatsby-multilingual",
   "private": true,
   "license": "MIT",
+  "custom_flag": "custom_value",
   "repository": "github:ervasive/gatsby-multilingual",
   "scripts": {
     "ts:compile": "tsc --build",


### PR DESCRIPTION
Add package.json and package-lock.json files to the list of paths that will be checked for changes to instruct the CI to run all job steps from the workflows. This allows greenkeeper to validate any dependency updates to the root repo project.